### PR TITLE
Correctly tag trailing functional qualifiers

### DIFF
--- a/autogenerated/cpp.tmLanguage.json
+++ b/autogenerated/cpp.tmLanguage.json
@@ -13166,27 +13166,27 @@
       "name": "meta.qualified_type.cpp"
     },
     "qualifiers_and_specifiers_post_parameters": {
-      "match": "((?:((?:(?>(?:\\s)+)|\\/\\*(?:[^\\*]|(?:\\*)++[^\\/])*+(?:\\*)++\\/)+)|(?:\\b)|(?=\\W)|(?<=\\W)|(?:\\A)|(?:\\Z)))((?:((?:((?:(?>(?:\\s)+)|\\/\\*(?:[^\\*]|(?:\\*)++[^\\/])*+(?:\\*)++\\/)+)|(?:\\b)|(?=\\W)|(?<=\\W)|(?:\\A)|(?:\\Z)))(?<!\\w)(?:(?:override)|(?:volatile)|(?:noexcept)|(?:final)|(?:const))(?!\\w))+(?=\\s*(?:(?:\\{|;)|[\\n\\r])))",
+      "match": "((?:(?:(?:(?:(?>(?:\\s)+)|\\/\\*(?:[^\\*]|(?:\\*)++[^\\/])*+(?:\\*)++\\/)+)|(?:\\b)|(?=\\W)|(?<=\\W)|(?:\\A)|(?:\\Z))(?<!\\w)(?:(?:override)|(?:volatile)|(?:noexcept)|(?:final)|(?:const))(?!\\w))+)(?=\\s*(?:(?:\\{|;)|[\\n\\r]))",
       "captures": {
         "1": {
           "patterns": [
             {
-              "include": "#inline_comment"
-            }
-          ]
-        },
-        "2": {
-          "patterns": [
-            {
-              "match": "(?:(?>(?:\\s)+)|(\\/\\*)((?:[^\\*]|(?:\\*)++[^\\/])*+((?:\\*)++\\/)))",
+              "match": "((?:(?:(?:(?>(?:\\s)+)|(\\/\\*)((?:[^\\*]|(?:\\*)++[^\\/])*+((?:\\*)++\\/)))+)|(?:\\b)|(?=\\W)|(?<=\\W)|(?:\\A)|(?:\\Z)))((?<!\\w)(?:(?:override)|(?:volatile)|(?:noexcept)|(?:final)|(?:const))(?!\\w))",
               "captures": {
                 "1": {
-                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
                 },
                 "2": {
-                  "name": "comment.block.cpp"
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
                 },
                 "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
                   "patterns": [
                     {
                       "match": "\\*\\/",
@@ -13197,43 +13197,9 @@
                       "name": "comment.block.cpp"
                     }
                   ]
-                }
-              }
-            }
-          ]
-        },
-        "3": {
-          "name": "storage.modifier.specifier.functional.post-parameters.$3.cpp"
-        },
-        "4": {
-          "patterns": [
-            {
-              "include": "#inline_comment"
-            }
-          ]
-        },
-        "5": {
-          "patterns": [
-            {
-              "match": "(?:(?>(?:\\s)+)|(\\/\\*)((?:[^\\*]|(?:\\*)++[^\\/])*+((?:\\*)++\\/)))",
-              "captures": {
-                "1": {
-                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
                 },
-                "2": {
-                  "name": "comment.block.cpp"
-                },
-                "3": {
-                  "patterns": [
-                    {
-                      "match": "\\*\\/",
-                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
-                    },
-                    {
-                      "match": "\\*",
-                      "name": "comment.block.cpp"
-                    }
-                  ]
+                "5": {
+                  "name": "storage.modifier.specifier.functional.post-parameters.$5.cpp"
                 }
               }
             }

--- a/autogenerated/cpp_scopes.txt
+++ b/autogenerated/cpp_scopes.txt
@@ -399,7 +399,7 @@ storage.modifier.lambda.$0.cpp
 storage.modifier.pointer.cpp
 storage.modifier.reference.cpp
 storage.modifier.specifier.$3.cpp
-storage.modifier.specifier.functional.post-parameters.$3.cpp
+storage.modifier.specifier.functional.post-parameters.$5.cpp
 storage.modifier.specifier.functional.pre-parameters.$0.cpp
 storage.modifier.specifier.parameter.cpp
 storage.type.$0.cpp

--- a/language_examples/#489.spec.yaml
+++ b/language_examples/#489.spec.yaml
@@ -102,13 +102,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.member.destructor
 - source: noexcept
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.noexcept
-    - override
 - source: override
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.noexcept
-    - override
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.override
 - source: '{'
   scopes:
     - >-

--- a/language_examples/#511.spec.yaml
+++ b/language_examples/#511.spec.yaml
@@ -34,13 +34,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: override
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.override
-    - final
 - source: final
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.override
-    - final
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.final
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition

--- a/language_examples/feature_basic_string_sso.spec.yaml
+++ b/language_examples/feature_basic_string_sso.spec.yaml
@@ -12429,13 +12429,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -12485,13 +12483,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -12567,13 +12563,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - >-
@@ -12718,13 +12712,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -12768,13 +12760,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -12875,13 +12865,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -12937,13 +12925,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -13053,13 +13039,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -13112,13 +13096,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -13237,13 +13219,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -13308,13 +13288,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -13393,15 +13371,14 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
   scopesEnd:
     - meta.function.definition
     - meta.head.function.definition
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -13423,13 +13400,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -13473,13 +13448,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition

--- a/language_examples/feature_operator_overload.spec.yaml
+++ b/language_examples/feature_operator_overload.spec.yaml
@@ -433,13 +433,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - >-
@@ -487,13 +485,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - >-

--- a/language_examples/misc_asteria.spec.yaml
+++ b/language_examples/misc_asteria.spec.yaml
@@ -499,13 +499,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -555,13 +553,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -616,13 +612,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -1178,13 +1172,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -1235,13 +1227,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -1320,13 +1310,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -1421,13 +1409,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -2075,13 +2061,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -2139,13 +2123,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -2203,13 +2185,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -2261,13 +2241,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - >-
@@ -4017,13 +3995,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - >-
@@ -4207,13 +4183,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - >-
@@ -4370,13 +4344,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - >-
@@ -21893,13 +21865,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition
@@ -22226,13 +22196,11 @@
   scopes:
     - punctuation.section.parameters.end.bracket.round
 - source: const
-  scopesBegin:
+  scopes:
     - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
 - source: noexcept
-  scopesEnd:
-    - storage.modifier.specifier.functional.post-parameters.const
-    - noexcept
+  scopes:
+    - storage.modifier.specifier.functional.post-parameters.noexcept
 - source: '{'
   scopes:
     - punctuation.section.block.begin.bracket.curly.function.definition

--- a/main/main.rb
+++ b/main/main.rb
@@ -367,16 +367,20 @@ grammar = Grammar.new(
         tag_as: "storage.modifier.specifier.functional.pre-parameters.$match"
     )
     grammar[:qualifiers_and_specifiers_post_parameters] = Pattern.new(
-        std_space.then(
-            tag_as: "storage.modifier.specifier.functional.post-parameters.$match",
-            match: Pattern.new(
-                oneOrMoreOf(std_space.then(variableBounds[ @cpp_tokens.that(:canAppearAfterParametersBeforeBody) ])).lookAheadFor(
-                    Pattern.new(/\s*/).then(
-                        Pattern.new(/\{/).or(/;/).or(/[\n\r]/)
-                    )
-                )
+        should_partially_match: ["final override;", "const noexcept {"],
+        match: oneOrMoreOf(std_space.then(
+            Pattern.new(
+                should_fully_match: ["override", "final", "const", "noexcept"],
+                should_not_fully_match: ["const noexcept"],
+                should_not_partial_match: ["return"],
+                tag_as: "storage.modifier.specifier.functional.post-parameters.$match",
+                match: variableBounds[ @cpp_tokens.that(:canAppearAfterParametersBeforeBody) ]
             )
-        ),
+        )).lookAheadFor(
+            Pattern.new(/\s*/).then(
+                Pattern.new(/\{/).or(/;/).or(/[\n\r]/)
+            )
+        )
     )
     grammar[:storage_specifiers] = storage_specifier = Pattern.new(
         std_space.then(


### PR DESCRIPTION
When multiple trailing qualifiers are present, the scopes are not properly computed, see comment on issue  https://github.com/jeff-hykin/better-cpp-syntax/issues/511