### PR TITLE
Pack indexing

### DIFF
--- a/language_examples/pack_indexing.cpp
+++ b/language_examples/pack_indexing.cpp
@@ -1,0 +1,4 @@
+template <typename... T>
+constexpr auto first_plus_last(T... values) -> T...[0] {
+    return T...[0](values...[0] + values...[sizeof...(values)-1]);
+}

--- a/language_examples/pack_indexing.spec.yaml
+++ b/language_examples/pack_indexing.spec.yaml
@@ -1,0 +1,140 @@
+- source: template
+  scopes:
+    - storage.type.template
+- source: <
+  scopes:
+    - punctuation.section.angle-brackets.begin.template.definition
+- source: typename
+  scopesBegin:
+    - meta.template.definition
+  scopes:
+    - storage.type.template.argument.typename
+- source: ...
+  scopes:
+    - punctuation.vararg-ellipses.template.definition
+- source: T
+  scopes:
+    - entity.name.type.template
+  scopesEnd:
+    - meta.template.definition
+- source: '>'
+  scopes:
+    - punctuation.section.angle-brackets.end.template.definition
+- source: constexpr
+  scopesBegin:
+    - meta.function.definition
+  scopes:
+    - storage.modifier.constexpr
+- source: auto
+  scopes:
+    - meta.qualified-type
+    - storage.type.primitive
+    - storage.type.built-in.primitive
+- source: first_plus_last
+  scopesBegin:
+    - meta.head.function.definition
+  scopes:
+    - entity.name.function.definition
+- source: (
+  scopes:
+    - punctuation.section.parameters.begin.bracket.round
+- source: T
+  scopesBegin:
+    - meta.function.definition.parameters
+    - meta.parameter
+  scopes:
+    - entity.name.type.parameter
+- source: ...
+  scopes:
+    - punctuation.vararg-ellipses
+- source: values
+  scopes:
+    - variable.parameter
+  scopesEnd:
+    - meta.function.definition.parameters
+    - meta.parameter
+- source: )
+  scopes:
+    - punctuation.section.parameters.end.bracket.round
+- source: '->'
+  scopes:
+    - punctuation.separator.pointer-access
+- source: T
+  scopes:
+    - variable.other.property
+- source: ...
+- source: '['
+  scopesBegin:
+    - meta.bracket.square.access
+  scopes:
+    - punctuation.definition.begin.bracket.square
+- source: '0'
+  scopes:
+    - constant.numeric.decimal
+- source: ']'
+  scopes:
+    - punctuation.definition.end.bracket.square
+  scopesEnd:
+    - meta.bracket.square.access
+- source: '{'
+  scopes:
+    - punctuation.section.block.begin.bracket.curly.function.definition
+  scopesEnd:
+    - meta.head.function.definition
+- source: return
+  scopesBegin:
+    - meta.body.function.definition
+  scopes:
+    - keyword.control.return
+- source: 'T...['
+- source: '0'
+  scopes:
+    - constant.numeric.decimal
+- source: ']'
+- source: (
+  scopesBegin:
+    - meta.parens
+  scopes:
+    - punctuation.section.parens.begin.bracket.round
+- source: 'values...['
+- source: '0'
+  scopes:
+    - constant.numeric.decimal
+- source: ']'
+- source: +
+  scopes:
+    - keyword.operator.arithmetic
+- source: 'values...['
+- source: sizeof...
+  scopes:
+    - keyword.operator.functionlike
+    - keyword.operator.sizeof.variadic
+- source: (
+  scopes:
+    - punctuation.section.arguments.begin.bracket.round.operator.sizeof.variadic
+- source: values
+  scopes:
+    - meta.arguments.operator.sizeof.variadic
+    - variable.lower-case
+    - variable.other.unknown.values
+- source: )
+  scopes:
+    - punctuation.section.arguments.end.bracket.round.operator.sizeof.variadic
+- source: '-'
+  scopes:
+    - keyword.operator.arithmetic
+- source: '1'
+  scopes:
+    - constant.numeric.decimal
+- source: ']'
+- source: )
+  scopes:
+    - punctuation.section.parens.end.bracket.round
+  scopesEnd:
+    - meta.parens
+- source: ;
+  scopes:
+    - punctuation.terminator.statement
+- source: '}'
+  scopes:
+    - punctuation.section.block.end.bracket.curly.function.definition

--- a/main/main.rb
+++ b/main/main.rb
@@ -274,6 +274,7 @@ grammar = Grammar.new(
             :functional_specifiers_pre_parameters,      # TODO: these probably need to be moved inside the function definition pattern
             :storage_types,
             # misc
+            :pack_indexing,
             :lambdas,
             :attributes_context, # this is here because it needs to be lower than :operators. TODO: once all the contexts are cleaned up, this should be put in a better spot
             :parentheses,
@@ -2203,6 +2204,23 @@ grammar = Grammar.new(
                 )
         ],
         )
+
+#
+# Pack indexing
+#
+    grammar[:pack_indexing] = PatternRange.new(
+        start_pattern: Pattern.new(
+            match: identifier,
+        ).maybe(@spaces).then(
+            match: /\.\.\./,
+        ).maybe(@spaces).then(
+            match: /\[/,
+        ),
+        end_pattern: Pattern.new(
+            match: /\]/,
+        ),
+        includes: [:evaluation_context]
+    )
 
 #
 # Lambdas


### PR DESCRIPTION
Fixes https://github.com/jeff-hykin/better-cpp-syntax/issues/677.

I'm not happy with the `->` being mistagged, but I'm also not excited about fixing it for [pack-index-specifier](https://eel.is/c++draft/dcl.type.pack.index#nt:pack-index-specifier) while keeping it broken for [decltype-specifier](https://eel.is/c++draft/dcl.type.decltype#nt:decltype-specifier) (see [computed-type-specifier](https://eel.is/c++draft/dcl.type.simple#nt:computed-type-specifier), [simple-type-specifier](https://eel.is/c++draft/dcl.type.simple#nt:simple-type-specifier), [type-specifier](https://eel.is/c++draft/dcl.type.general#nt:type-specifier), [type-specifier-seq](https://eel.is/c++draft/dcl.type.general#nt:type-specifier-seq), [type-id](https://eel.is/c++draft/dcl.name#nt:type-id), [trailing-return-type](https://eel.is/c++draft/dcl.decl.general#nt:trailing-return-type)), and I'm not sure if trying to update the pattern in `qualified_type` is the right approach.

Also I'll need help with scope naming because I don't understand the naming scheme.