### PR TITLE
Add .cppm extension

### DIFF
--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -10,6 +10,7 @@
   "fileTypes": [
     "cc",
     "cpp",
+    "cppm",
     "cp",
     "cxx",
     "c++",


### PR DESCRIPTION
This adds the `.cppm` extension for C++20 modules.